### PR TITLE
'j' global variable and asynchronous events errors

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1,11 +1,11 @@
 !function(win, doc, timeout) {
   var script = doc.getElementsByTagName("script")[0],
       list = {}, ids = {}, delay = {}, re = /^i|c/,
-      scripts = {}, s = 'string', f = false, i,
+      scripts = {}, s = 'string', f = false,
       push = 'push', domContentLoaded = 'DOMContentLoaded', readyState = 'readyState',
       addEventListener = 'addEventListener', onreadystatechange = 'onreadystatechange',
       every = function(ar, fn) {
-        for (i = 0, j = ar.length; i < j; ++i) {
+        for (var i = 0, j = ar.length; i < j; ++i) {
           if (!fn(ar[i])) {
             return 0;
           }


### PR DESCRIPTION
This avoids the creation of the j global variable and makes the each function more secure on asynchronous events, by using a scoped variable that wont be changed by other events being executed at the same time. Fixes a very rare and hard to debug problem i was having.
