### PR TITLE
Ensure "done" callback is invoked if zero-length paths array is provided

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -44,18 +44,22 @@
         }
       }
     }
-    setTimeout(function () {
-      each(paths, function (path) {
-        if (path === null) return callback()
-        if (scripts[path]) {
+    if(paths.length === 0) {
+      if(done) done();
+    } else {
+      setTimeout(function () {
+        each(paths, function (path) {
+          if (path === null) return callback()
+          if (scripts[path]) {
+            id && (ids[id] = 1)
+            return scripts[path] == 2 && callback()
+          }
+          scripts[path] = 1
           id && (ids[id] = 1)
-          return scripts[path] == 2 && callback()
-        }
-        scripts[path] = 1
-        id && (ids[id] = 1)
-        create(!/^https?:\/\//.test(path) && scriptpath ? scriptpath + path + '.js' : path, callback)
-      })
-    }, 0)
+          create(!/^https?:\/\//.test(path) && scriptpath ? scriptpath + path + '.js' : path, callback)
+        })
+      }, 0)
+    }
     return $script
   }
 


### PR DESCRIPTION
It is uncommon but possible for script.js to be invoked with [] paths.  Current behavior is to never fire the "done" callback, this fix ensures it's called immediately and skips the setTimeout.

Github's diff is a bit misleading - it shows mostly whitespace.  I've only added a one-line if statement.
