### PR TITLE
Added bower.json descriptor with "main"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,10 @@
+{
+  "name": "script.js",
+  "description": "Asyncronous JavaScript loader and dependency manager",
+  "version": "2.5.2",
+  "homepage": "https://github.com/ded/script.js",
+  "authors": [
+    "Dustin Diaz <dustin@dustindiaz.com> (http://dustindiaz.com)"
+  ],
+  "main": "./dist/script.js"
+}


### PR DESCRIPTION
For valid bower packaging, the main files are required. Those are added in this bower.json file
