### PR TITLE
$script doesn't actually provide support for IE7/8

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -27,6 +27,23 @@
     })
   }
 
+  if (!Function.prototype.bind) {
+    Function.prototype.bind = function(obj) {
+      if (typeof this !== 'function') {
+        throw new TypeError('Not bind-able');
+      }
+      var args = Array.prototype.slice.call(arguments, 1),
+        toBind = this,
+        nop = function() {},
+        bind = function() {
+          return toBind.apply(this instanceof nop && obj ? this : obj, args.concat(Array.prototype.slice.call(arguments)));
+        };
+        nop.prototype = this.prototype;
+        bind.prototype = new nop();
+        return bind;
+    };
+  }
+
   function $script(paths, idOrDone, optDone) {
     paths = paths[push] ? paths : [paths]
     var idOrDoneIsDone = idOrDone && idOrDone.call


### PR DESCRIPTION
Without a polyfill for the Function.prototype.bind method in use, this
script will not function correctly in IE7 and IE8. The issue is that
this wasn't included by microsoft until IE9.

http://msdn.microsoft.com/en-us/library/ie/ff841995(v=vs.94).aspx

Sam O.
