### PR TITLE
fix(callback): callback was called twice when lib was already loaded

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -51,8 +51,7 @@
         path = !force && path.indexOf('.js') === -1 && !/^https?:\/\//.test(path) && scriptpath ? scriptpath + path + '.js' : path
         if (scripts[path]) {
           if (id) ids[id] = 1
-          if (scripts[path] == 2) callback()
-          else return setTimeout(function () { loading(path, true) }, 0)
+          return (scripts[path] == 2) ? callback() : setTimeout(function () { loading(path, true) }, 0)
         }
 
         scripts[path] = 1

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -133,6 +133,14 @@ script('../node_modules/domready/ready.js', function () {
         script('double-load', load)
       })
 
+      test('correctly count loaded scripts', function (done){
+        script.path('../vendor/')
+        script(['patha', 'pathb', 'http://ded.github.com/morpheus/morpheus.js', 'http://ajax.googleapis.com/ajax/libs/angularjs/1.2.19/angular.js'], function () {
+          ok(typeof angular !== 'undefined', 'loaded angular.js from http')
+          done();
+        })
+      })
+
     })
     start()
   })


### PR DESCRIPTION
When $script was used with lists with shared scripts, the inside `callback()` was called twice for previously loaded libraries, and this caused the `done()` to be called before the scripts were loaded.
Side bonus: 21 bytes less in minified library
