### PR TITLE
Give user more control over fetch time

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -45,20 +45,18 @@
         }
       }
     }
-    setTimeout(function () {
-      each(paths, function loading(path, force) {
-        if (path === null) return callback()
-        path = !force && path.indexOf('.js') === -1 && !/^https?:\/\//.test(path) && scriptpath ? scriptpath + path + '.js' : path
-        if (scripts[path]) {
-          if (id) ids[id] = 1
-          return (scripts[path] == 2) ? callback() : setTimeout(function () { loading(path, true) }, 0)
-        }
-
-        scripts[path] = 1
+    each(paths, function loading(path, force) {
+      if (path === null) return callback()
+      path = !force && path.indexOf('.js') === -1 && !/^https?:\/\//.test(path) && scriptpath ? scriptpath + path + '.js' : path
+      if (scripts[path]) {
         if (id) ids[id] = 1
-        create(path, callback)
-      })
-    }, 0)
+        return (scripts[path] == 2) ? callback() : setTimeout(function () { loading(path, true) }, 0)
+      }
+
+      scripts[path] = 1
+      if (id) ids[id] = 1
+      create(path, callback)
+    })
     return $script
   }
 


### PR DESCRIPTION
Currently, $script uses a setTimeout() call to defer script fetching which makes it difficult to execute javascript before the window "load" event fires. Removing setTimeout() will give developers more control over fetch time and make it possible to execute javascript before the page is displayed to the user:

```html
<!-- in <head> -->
<script>
  // fetch jquery.js before DOMContentLoaded
  $script('path-to-jquery.js', 'jquery');

  // markup page after DOMContentLoaded
  $script.ready('jquery', function() {
    jQuery(document).ready(function() {

    });
  });
</script>
```