### PR TITLE
The $scipt.path('/modules/') was not working for .js files

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -48,7 +48,11 @@
     setTimeout(function () {
       each(paths, function loading(path, force) {
         if (path === null) return callback()
-        path = !force && path.indexOf('.js') === -1 && !/^https?:\/\//.test(path) && scriptpath ? scriptpath + path + '.js' : path
+        
+        if (!force && !/^https?:\/\//.test(path) && scriptpath) {
+          path = (path.indexOf('.js') === -1) ? scriptpath + path + '.js' : scriptpath + path;
+        }
+        
         if (scripts[path]) {
           if (id) ids[id] = 1
           return (scripts[path] == 2) ? callback() : setTimeout(function () { loading(path, true) }, 0)


### PR DESCRIPTION
You only applied scriptpath if the file didn't include '.js'. I think it should work for .js files as well. In the change I removed the condition of indexOf('.js')===-1, and added a part where I add '.js' if the file doesn't end with .js.