### PR TITLE
Adding license info to the package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "loader"
   ],
   "version": "2.5.8",
+  "license": "MIT",
   "homepage": "https://github.com/ded/script.js",
   "author": "Dustin Diaz <dustin@dustindiaz.com> (http://dustindiaz.com)",
   "contributors": [


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the package.json it becomes available through the public NPMRegistry API and that way other tools like VersionEye can fetch it easier.